### PR TITLE
[FEAT] Delete 기능 구현

### DIFF
--- a/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
+++ b/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
@@ -6,11 +6,13 @@ import com.ezmeal.common.exception.types.ForbiddenException;
 import com.ezmeal.common.exception.types.NotFoundException;
 import com.ezmeal.cs.application.dto.command.InquiryAnswerCommand;
 import com.ezmeal.cs.application.dto.command.InquiryCreateCommand;
+import com.ezmeal.cs.application.dto.command.InquiryDeleteCommand;
 import com.ezmeal.cs.application.dto.command.InquiryUpdateCommand;
 import com.ezmeal.cs.application.dto.response.InquiryResponse;
 import com.ezmeal.cs.domain.event.InquiryEventProducer;
 import com.ezmeal.cs.domain.event.payload.publish.InquiryAnsweredEvent;
 import com.ezmeal.cs.domain.event.payload.publish.InquiryCreatedEvent;
+import com.ezmeal.cs.domain.event.payload.publish.InquiryDeletedEvent;
 import com.ezmeal.cs.domain.event.payload.publish.InquiryUpdatedEvent;
 import com.ezmeal.cs.domain.exception.InquiryErrorCode;
 import com.ezmeal.cs.domain.model.Inquiry;
@@ -159,6 +161,34 @@ public class InquiryService {
         Page<Inquiry> inquiryPage = inquiryRepository.searchActiveInquiries(condition, pageable);
         // 엔티티를 DTO로 변환하여 반환 (Page 인터페이스의 map 활용)
         return inquiryPage.map(InquiryResponse::from);
+    }
+
+    // 문의글 삭제 (작성자 또는 관리자)
+    public void deleteInquiry(InquiryDeleteCommand command) {
+        Inquiry deletedInquiry = transactionTemplate.execute(status -> {
+            Inquiry inquiry = inquiryRepository.findActiveById(command.csId())
+                    .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+            // 권한 검증 (Inquiry에 있는 checkRole 메서드 활용)
+            if (!inquiry.checkRole(command.userId(), command.role())) {
+                throw new ForbiddenException(InquiryErrorCode.INQUIRY_FORBIDDEN);
+            }
+
+            inquiry.delete(command.userId());
+
+            return inquiry;
+        });
+
+        // 이벤트 발행
+        inquiryEventProducer.publishDeletedEvent(InquiryDeletedEvent.from(deletedInquiry));
+    }
+
+    // 유저 탈퇴 시 해당 유저의 문의 일괄 삭제 (Kafka 이벤트 수신용)
+    public void bulkSoftDeleteByUserId(String userId, String deletedBy) {
+        transactionTemplate.executeWithoutResult(status -> {
+            inquiryRepository.bulkSoftDeleteByUserId(userId, deletedBy);
+        });
+        log.info("유저({}) 탈퇴로 인해 작성한 모든 문의가 삭제 처리되었습니다. (deletedBy={})", userId, deletedBy);
     }
 
 }

--- a/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
+++ b/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
@@ -166,13 +166,13 @@ public class InquiryService {
     // 문의글 삭제 (작성자 또는 관리자)
     public void deleteInquiry(InquiryDeleteCommand command) {
         Inquiry deletedInquiry = transactionTemplate.execute(status -> {
-            Inquiry inquiry = inquiryRepository.findActiveById(command.csId())
-                    .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
 
-            // 권한 검증 (Inquiry에 있는 checkRole 메서드 활용)
-            if (!inquiry.checkRole(command.userId(), command.role())) {
-                throw new ForbiddenException(InquiryErrorCode.INQUIRY_FORBIDDEN);
-            }
+            // 관리자는 전체글 조회 가능, 일반 유저는 본인 글만 조회 (IDOR 고려)
+            Inquiry inquiry = command.role() == Role.ADMIN
+                    ? inquiryRepository.findActiveById(command.csId())
+                    .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND))
+                    : inquiryRepository.findActiveByIdAndUserId(command.csId(), command.userId())
+                            .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
 
             inquiry.delete(command.userId());
 

--- a/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
+++ b/src/main/java/com/ezmeal/cs/application/service/InquiryService.java
@@ -185,6 +185,12 @@ public class InquiryService {
 
     // 유저 탈퇴 시 해당 유저의 문의 일괄 삭제 (Kafka 이벤트 수신용)
     public void bulkSoftDeleteByUserId(String userId, String deletedBy) {
+
+        if (userId == null || userId.isBlank() || deletedBy == null || deletedBy.isBlank()) {
+            log.warn("일괄 삭제 처리 실패: 필수 입력값이 누락되었습니다. userId={}", userId);
+            throw new BadRequestException(InquiryErrorCode.INVALID_INPUT);
+        }
+
         transactionTemplate.executeWithoutResult(status -> {
             inquiryRepository.bulkSoftDeleteByUserId(userId, deletedBy);
         });

--- a/src/main/java/com/ezmeal/cs/infrastructure/message/kafka/consumer/InquiryEventListenerImpl.java
+++ b/src/main/java/com/ezmeal/cs/infrastructure/message/kafka/consumer/InquiryEventListenerImpl.java
@@ -90,13 +90,13 @@ public class InquiryEventListenerImpl {
         if ("SYSTEM".equals(userId)) {
             log.info("[Kafka] 시스템 요청으로 문의글({})을/를 삭제합니다.", message.csId());
             InquiryDeleteCommand systemCommand = message.toCommand("SYSTEM", Role.ADMIN);
-            // inquiryService.deleteInquiry(systemCommand);
+            inquiryService.deleteInquiry(systemCommand);
         } else {
             Role role = extractRoleHeader(roleBytes);
 
             log.info("[Kafka] 유저({})의 요청으로 문의글({})을/를 삭제합니다.", userId, message.csId());
             InquiryDeleteCommand command = message.toCommand(userId, role);
-            // inquiryService.deleteInquiry(command);
+            inquiryService.deleteInquiry(command);
         }
     }
 
@@ -131,7 +131,7 @@ public class InquiryEventListenerImpl {
     ) {
         String deletedBy = extractStringHeader(userIdBytes, "SYSTEM");
         log.info("[Kafka] ({})의 요청으로 유저의 모든 문의글 일괄 삭제를 수행합니다. 대상 유저: {}", deletedBy, message.userId());
-        // inquiryService.bulkSoftDeleteByUserId(message.userId(), deletedBy);
+        inquiryService.bulkSoftDeleteByUserId(message.userId(), deletedBy);
     }
 
     // ===================

--- a/src/main/java/com/ezmeal/cs/presentation/InquiryController.java
+++ b/src/main/java/com/ezmeal/cs/presentation/InquiryController.java
@@ -2,6 +2,7 @@ package com.ezmeal.cs.presentation;
 
 import com.ezmeal.common.response.CommonApiResponse;
 import com.ezmeal.common.security.principal.CustomUserPrincipal;
+import com.ezmeal.cs.application.dto.command.InquiryDeleteCommand;
 import com.ezmeal.cs.application.dto.response.InquiryResponse;
 import com.ezmeal.cs.application.service.InquiryService;
 import com.ezmeal.cs.domain.repository.dto.InquirySearchConditionDto;
@@ -17,6 +18,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -86,6 +88,22 @@ public class InquiryController {
     ) {
         Page<InquiryResponse> response = inquiryService.searchInquiries(condition, pageable);
         return ResponseEntity.ok(CommonApiResponse.success(response));
+    }
+
+    // 문의글 삭제 (작성자 또는 관리자)
+    @DeleteMapping("/{csId}")
+    public ResponseEntity<CommonApiResponse<Void>> deleteInquiry(
+            @PathVariable("csId") UUID csId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        InquiryDeleteCommand command = new InquiryDeleteCommand(
+                csId,
+                principal.getUserId(),
+                principal.getRole()
+        );
+        inquiryService.deleteInquiry(command);
+
+        return ResponseEntity.ok(CommonApiResponse.success(null));
     }
 
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #11 

## 📝 작업 내역

- [ ] 서비스 레이어 구현
- [ ] 컨트롤러 레이어 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문의 삭제 엔드포인트 추가: 사용자가 자신의 문의를 삭제할 수 있으며, 관리자 권한으로는 해당 문의를 관리자가 삭제할 수 있습니다.
  * 계정 삭제 연동된 일괄 처리: 사용자 계정이 삭제되면 해당 사용자의 모든 문의가 자동으로 일괄 삭제 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->